### PR TITLE
Fixes #2: Add license_severity and ignored_licenses inputs to run-trivy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ This [GitHub Action](./run-trivy/action.yml) runs a Trivy SCA scan on the specif
 - `skip_files` (optional): A comma-separated list of files not to scan.
 - `include_dev_dependencies` (optional): When `true` development dependencies are included in the scan. Default is "true".
 - `fail_on_db_error` (optional): When `true` the action will fail if Trivy cannot download the vulnerability DB (and perform the vulnerability scan). Default is "true".
+- `license_severity` (optional): Severity levels for license findings (e.g., `HIGH,CRITICAL`). When set, overrides the `severity` input for license scanning only.
+- `ignored_licenses` (optional): A comma-separated list of licenses to ignore (e.g., `MPL-2.0,LGPL-2.1`).
 
 **Requirements:**
 
@@ -66,6 +68,8 @@ jobs:
           skip_dirs: "dist"
           skip_files: "Dockerfile"
           include_dev_dependencies: "false"
+          license_severity: "CRITICAL"
+          ignored_licenses: "MPL-2.0"
 ```
 
 ## Contributing 🤝

--- a/run-trivy/action.yml
+++ b/run-trivy/action.yml
@@ -16,6 +16,11 @@
 #   - skip_files (optional): A comma-separated list of files not to scan.
 #   - include_dev_dependencies (optional): A boolean value to determine whether
 #     development dependencies should be included in the scan. Default is "true".
+#   - license_severity (optional): Severity levels for license findings
+#     (e.g., "HIGH,CRITICAL"). When set, overrides the severity input for
+#     license scanning only.
+#   - ignored_licenses (optional): A comma-separated list of licenses to ignore
+#     (e.g., "MPL-2.0,LGPL-2.1").
 #
 # Requirements
 #   - Trivy must be installed (e.g., 2Toad/actions/install-trivy)
@@ -71,6 +76,14 @@ inputs:
     description: "When true the action will fail if Trivy cannot download the vulnerability DB"
     required: false
     default: "true"
+  license_severity:
+    description: "Severity levels for license findings (e.g., HIGH,CRITICAL). When set, overrides the severity input for license scanning only."
+    required: false
+    default: ""
+  ignored_licenses:
+    description: "Comma-separated list of licenses to ignore (e.g., MPL-2.0,LGPL-2.1)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -84,6 +97,8 @@ runs:
           $([ -n "${{ inputs.skip_dirs }}" ] && echo "--skip-dirs ${{ inputs.skip_dirs }}") \
           $([ -n "${{ inputs.skip_files }}" ] && echo "--skip-files ${{ inputs.skip_files }}") \
           $([ "${{ inputs.include_dev_dependencies }}" = "true" ] && echo "--include-dev-deps") \
+          $([ -n "${{ inputs.license_severity }}" ] && echo "--license-severity ${{ inputs.license_severity }}") \
+          $([ -n "${{ inputs.ignored_licenses }}" ] && echo "--ignored-licenses ${{ inputs.ignored_licenses }}") \
           --ignore-unfixed \
           --no-progress \
           ${{ inputs.path }} \


### PR DESCRIPTION
Allow setting separate severity thresholds for license findings and ignoring specific reviewed licenses, so license detections like MPL-2.0 don't cause failures independent of vulnerability severity settings