### PR TITLE
Fixes #7: Pin Trivy version to 0.69.3

### DIFF
--- a/install-trivy/action.yml
+++ b/install-trivy/action.yml
@@ -17,7 +17,9 @@
 #
 #         - name: Install Trivy
 #           uses: 2Toad/actions/install-trivy@v1
-#   
+#           with:
+#             version: "0.69.3"  # optional, defaults to 0.69.3
+#
 #         - name: Run Trivy SCA Scan
 #           uses: 2Toad/actions/run-trivy@v1
 #           with:
@@ -28,6 +30,11 @@
 
 name: "Install Trivy"
 description: "Install Trivy SCA tool"
+inputs:
+  version:
+    description: "The version of Trivy to install (e.g., 0.69.3)"
+    required: false
+    default: "0.69.3"
 runs:
   using: "composite"
   steps:
@@ -39,4 +46,4 @@ runs:
         wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
         echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list
         sudo apt-get update
-        sudo apt-get install trivy -y
+        sudo apt-get install trivy=${{ inputs.version }} -y


### PR DESCRIPTION
Fixes #7 

Add version input to install-trivy action, defaulting to 0.69.3